### PR TITLE
fixed recipe-container overflow to not show behind buttons

### DIFF
--- a/app/assets/stylesheets/pages/_recipes.scss
+++ b/app/assets/stylesheets/pages/_recipes.scss
@@ -2,4 +2,6 @@
   padding: 10px;
   color: #0A4D71;
   font-family: 'Arial', sans-serif;
+  height: 560px;
+  overflow: scroll;
 }


### PR DESCRIPTION
-Added height, and over flow limits to .recipe-container

![image](https://github.com/chrononaut76/rails-shopwise/assets/155603647/f0f1e440-fb52-4e34-9899-8b6e876e1a9f)




![image](https://github.com/chrononaut76/rails-shopwise/assets/155603647/7c14b73b-12a5-4b94-addc-57708fefcae2)
