### PR TITLE
fixing hiding navbar & h1 when scrolling

### DIFF
--- a/app/assets/stylesheets/pages/_my_items.scss
+++ b/app/assets/stylesheets/pages/_my_items.scss
@@ -13,7 +13,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  position: relative;
+  position: fixed;
 }
 
 #empty-message {


### PR DESCRIPTION
-Changed position to fixed on .my-items-container to avoid scrolling and hiding navbar and h1 when scrolling down

Before

![image](https://github.com/chrononaut76/rails-shopwise/assets/155603647/aa192436-245b-4f00-80d4-a1ce85909bae)


After

![image](https://github.com/chrononaut76/rails-shopwise/assets/155603647/fab16c1b-92d7-4c3c-b2ca-74ad0c7f4adf)