### PR TITLE
fixed recipe-container overflow to not show behind buttons

### DIFF
--- a/app/assets/stylesheets/pages/_recipes.scss
+++ b/app/assets/stylesheets/pages/_recipes.scss
@@ -2,7 +2,7 @@
   padding: 10px;
   color: #0A4D71;
   font-family: 'Arial', sans-serif;
-  height: 560px;
+  height: 420px;
   overflow: scroll;
 }
 


### PR DESCRIPTION
- Changed .recipe-container height from 560px to 420px

Before

![image](https://github.com/chrononaut76/rails-shopwise/assets/155603647/97837d34-7c22-437a-8ca1-94fd6bd1565a)


After

![image](https://github.com/chrononaut76/rails-shopwise/assets/155603647/a5d7e953-5e8d-473f-98ee-ce750a4b358b)